### PR TITLE
chore: Add IPAddress field to NewContainerSpec

### DIFF
--- a/models.go
+++ b/models.go
@@ -96,6 +96,7 @@ type NewContainerSpec struct {
 	Runtime       string            `json:"runtime"`
 	Privileged    bool              `json:"privileged"`
 	Operation     string            `json:"operation"`
+	IPAddress     string            `json:"ipAddress"`
 	Devices       []Devices         `json:"devices"`
 	Volumes       []Volumes         `json:"volumes"`
 	PortBindings  []PortBindings    `json:"portbindings"`


### PR DESCRIPTION
Add static IP address to new container spec model, this will allow static ip setting while passing the create call to QNAP container station